### PR TITLE
Update README.md: fix a typo on "achievement"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![](./demo/intro.gif)
 
 * Code to keep your Marble happy
-* Hundreds of achivements
+* Hundreds of achievements
 * Daily quests _(coming soon)_
 * 100% local, no tracking
 


### PR DESCRIPTION
Some commit messages may be rewritten.
For instance, "achivements: rename too long achivement ":  https://github.com/sturdy-dev/marblezero/commit/0000022065eb86bcb240e45c505e94f9a37b11a7 😉